### PR TITLE
deprecate `__version__` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Version 0.17.0
+--------------
+
+Unreleased
+
+-   The `__version__` attribute is deprecated. Use feature detection, or
+    `importlib.metadata.version("flask-classful")`, instead. #155
+
+
 2023-09-07 F.N. Claessen <felix@seita.nl>
 -----------------------------------------
 

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -19,8 +19,6 @@ import re
 
 _py2 = sys.version_info[0] == 2
 
-__version__ = "0.16.0"
-
 
 def route(rule, **options):
     """A decorator that is used to define custom routes for methods in
@@ -525,3 +523,19 @@ def unpack(value):
 
 class DecoratorCompatibilityError(Exception):
     pass
+
+
+def __getattr__(name):
+    if name == "__version__":
+        import importlib.metadata
+        import warnings
+
+        warnings.warn(
+            "The '__version__' attribute is deprecated and will be removed in"
+            " Flask-Classful 1.0. Use feature detection, or"
+            ' `importlib.metadata.version("flask-classful")`, instead.'
+        )
+        return importlib.metadata.version("flask-classful")
+
+
+    raise AttributeError(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "Flask-Classful"
+version = "0.17.0.dev"
 description = "Class based views for Flask"
 readme = "README.rst"
 license = { file = "LICENSE" }
@@ -17,7 +18,6 @@ requires-python = ">=3.7"
 dependencies = [
     "flask>=0.12.5",
 ]
-dynamic = ["version"]
 
 [project.urls]
 Source = "https://github.com/pallets-eco/flask-classful/"


### PR DESCRIPTION
`importlib.metadata.version("flask-classful")` is the standard way to get the version from project metadata.

This also starts version 0.17.0.