### PR TITLE
only trigger CI on push to main

### DIFF
--- a/.github/workflows/lint-test-docs.yaml
+++ b/.github/workflows/lint-test-docs.yaml
@@ -2,14 +2,9 @@ name: Lint, Test & Docs
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-  # to trigger manually with webhook
-  # curl -X POST https://api.github.com/repos/:owner/:repo/dispatches \
-  # -H 'Accept: application/vnd.github.everest-preview+json' \
-  # -H 'Authorization: token TOKEN_VALUE_HERE' \
-  # --data '{"event_type":"lint-test-docs","client_payload":{}}'
-  repository_dispatch:
-    types: [lint-test-docs]
 
 jobs:
 


### PR DESCRIPTION
This prevents CI from running double for each PR branch. CI runs when merging into main, and on each PR, but doesn't double up.