### PR TITLE
drop python<3.8, remove old compat

### DIFF
--- a/.github/workflows/lint-test-docs.yaml
+++ b/.github/workflows/lint-test-docs.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         requirements:
           - "flask>=1.0,<1.1 werkzeug<2.1 jinja2<3 markupsafe<2.1 itsdangerous<2.1"
           - "flask>=1.1,<1.2 markupsafe==2.0.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Version 0.17.0
 
 Unreleased
 
+-   Drop support for Python < 3.8.
+-   Remove old Python 2 compatibility checks.
 -   The `__version__` attribute is deprecated. Use feature detection, or
     `importlib.metadata.version("flask-classful")`, instead. #155
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "flask>=0.12.5",
 ]


### PR DESCRIPTION
[Python 3.7 reached end of life on 2023-07-27.](https://endoflife.date/python)

Removed some leftover compat code for Python 2.