### PR TITLE
drop support for Flask < 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Version 0.17.0
 Unreleased
 
 -   Drop support for Python < 3.8.
+-   Drop support for Flask < 2.0. #159
 -   Remove old Python 2 compatibility checks.
 -   The `__version__` attribute is deprecated. Use feature detection, or
     `importlib.metadata.version("flask-classful")`, instead. #155

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "flask>=1",
+    "flask>=2.0",
 ]
 
 [project.urls]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,6 +1,4 @@
 import flask
-import pytest
-from packaging import version
 
 from .view_classes import AfterRequestAsyncView
 from .view_classes import AfterViewAsyncView
@@ -16,11 +14,8 @@ AfterViewAsyncView.register(app)
 AfterRequestAsyncView.register(app)
 
 client = app.test_client()
-skip_test = version.parse(flask.__version__) < version.parse("2")
-skip_reason = "Skipping async views tests for Flask<2..."
 
 
-@pytest.mark.skipif(condition=skip_test, reason=skip_reason)
 def test_async_view():
     resp = client.get("/async/")
     assert b"GET" == resp.data
@@ -28,25 +23,21 @@ def test_async_view():
     assert b"POST" == resp.data
 
 
-@pytest.mark.skipif(condition=skip_test, reason=skip_reason)
 def test_async_before_request():
     resp = client.get("/before-request-async/")
     assert b"Before Request" == resp.data
 
 
-@pytest.mark.skipif(condition=skip_test, reason=skip_reason)
 def test_async_before_view():
     resp = client.get("/before-view-async/")
     assert b"Before View" == resp.data
 
 
-@pytest.mark.skipif(condition=skip_test, reason=skip_reason)
 def test_async_after_view():
     resp = client.get("/after-view-async/")
     assert b"After View" == resp.data
 
 
-@pytest.mark.skipif(condition=skip_test, reason=skip_reason)
 def test_async_after_request():
     resp = client.get("/after-request-async/")
     assert b"After Request" == resp.data

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,8 @@ package = wheel
 wheel_build_env = .pkg
 deps =
     -r requirements/tests.txt
-    min: flask<1.1
-    min: werkzeug<2.1
-    min: jinja2<3
-    min: markupsafe<2.1
-    min: itsdangerous<2
+    min: flask<2.1
+    min: werkzeug<2.3
 constrain_package_deps = true
 use_frozen_constraints = true
 commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
This moves support closer to the current supported version of Flask (2.2). In Flask-Classful 1.0, we should probably bump it to `flask>=2.2`.

No longer need compat for `ensure_async`.

closes #159 