### PR TITLE
Document `@method` usage, and custom method for endpoint in general

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -635,8 +635,8 @@ route:
 **method**    GET, POST
 ============ ================================
 
-"But I don't want all endpointes use same method!" I hear you cry. Worry not!
-You have two options how to create endpoint with different methods.
+"But I don't want all endpoints to use the same method!" I hear you cry. Worry not!
+You have two options how to create endpoints with different methods.
 
 Let's see the first one: ::
 
@@ -644,14 +644,11 @@ Let's see the first one: ::
 
     class MyResourceView(FlaskView):
 
-        def edit(self, id):
+        @route("do-something-cool", methods=["POST"])
+        def do_something_cool(self):
             ...
 
-        @route("update/<id>", methods=["POST"])
-        def update(self, id):
-            ...
-
-``@route`` is an old friend of ours, but I didn't tell you earlier that it can also set methods, right? Well, now you know. As you can see, ``methods`` can accept multiple values, so you can set multiple methods for one endpoint (but again, but recommanded).
+``@route`` is an old friend of ours, but I didn't tell you earlier that it can also set methods, right? Well, now you know. As you can see, ``methods`` can accept multiple values, so you can set multiple methods for one endpoint (but again, not recommended).
 
 But there's also a second way, that some might consider nicer: ::
 
@@ -659,21 +656,18 @@ But there's also a second way, that some might consider nicer: ::
 
     class MyResourceView(FlaskView):
 
-        def edit(self, id):
-            ...
-
         @method("post")
-        def update(self, id):
+        def do_something_cool(self):
             ...
 
-``@method`` is a new decorator (since v0.16), that can be used to set method for one endpoint. So, if you only want to set method, and not custom route, this is the way to go.
+``@method`` is a new decorator (since v0.16), that can be used to set a method for one endpoint. So, if you only want to set a method, and not a custom route, this is the way to go.
 By the way, you can write either ``post`` or ``POST``, that's up to your preference.
 
-What? You ask if you can have multiple methods for same endpoint with this decorator? Didn't you hear about why it's not that great? Ugh, ok, here you are: ::
+What? You ask if you can have multiple methods for the same endpoint with this decorator? Didn't you hear about why it's not that great? Ugh, ok, here you are: ::
 
     @method("get")
     @method("post")
-    def update(self, id):
+    def do_or_see_something_cool(self):
         ...
 
 Hope you are happy.
@@ -681,11 +675,11 @@ Hope you are happy.
 Just a bit of warning. Be careful when you decide to combine these two ways. What would you guess happens when you do this? ::
 
     @method("post")
-    @route("update/<int:id>")
-    def update(self, id):
+    @route("my-custom-path/<int:id>")
+    def do_or_see_something_cool(self):
         ...
 
-Well, ``@method("post")`` is ignored, and you only get ``update`` with method ``GET``. So be careful.
+Well, ``@method("post")`` is ignored, and you only get ``do_or_see_something_cool`` with method ``GET``. So be careful.
 
 Hiding your own methods (they're not *all* special!)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -648,7 +648,7 @@ Let's see the first one: ::
         def do_something_cool(self):
             ...
 
-``@route`` is an old friend of ours, but I didn't tell you earlier that it can also set methods, right? Well, now you know. As you can see, ``methods`` can accept multiple values, so you can set multiple methods for one endpoint (but again, not recommended).
+``@route`` is an old friend of ours, but I didn't tell you earlier that it can also set methods, right? Well, now you know. As you can see, ``methods`` can accept multiple values, so you can set multiple methods for one endpoint.
 
 But there's also a second way, that some might consider nicer: ::
 
@@ -663,7 +663,7 @@ But there's also a second way, that some might consider nicer: ::
 ``@method`` is a new decorator (since v0.16), that can be used to set a method for one endpoint. So, if you only want to set a method, and not a custom route, this is the way to go.
 By the way, you can write either ``post`` or ``POST``, that's up to your preference.
 
-What? You ask if you can have multiple methods for the same endpoint with this decorator? Didn't you hear about why it's not that great? Ugh, ok, here you are: ::
+What? You ask if you can have multiple methods for the same endpoint with this decorator? Ok, here you are: ::
 
     @method("get")
     @method("post")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -639,16 +639,17 @@ route:
 You have two options how to create endpoint with different methods.
 
 Let's see the first one: ::
+
     from flask_classful import route
 
     class MyResourceView(FlaskView):
 
         def edit(self, id):
-            # this shows some template probably
+            ...
 
         @route("update/<id>", methods=["POST"])
         def update(self, id):
-            # this does some logic
+            ...
 
 ``@route`` is an old friend of ours, but I didn't tell you earlier that it can also set methods, right? Well, now you know. As you can see, ``methods`` can accept multiple values, so you can set multiple methods for one endpoint (but again, but recommanded).
 
@@ -659,21 +660,21 @@ But there's also a second way, that some might consider nicer: ::
     class MyResourceView(FlaskView):
 
         def edit(self, id):
-            # this shows some template probably
+            ...
 
         @method("post")
         def update(self, id):
-            # this does some logic
+            ...
 
 ``@method`` is a new decorator (since v0.16), that can be used to set method for one endpoint. So, if you only want to set method, and not custom route, this is the way to go.
 By the way, you can write either ``post`` or ``POST``, that's up to your preference.
 
 What? You ask if you can have multiple methods for same endpoint with this decorator? Didn't you hear about why it's not that great? Ugh, ok, here you are: ::
 
-        @method("get")
-        @method("post")
-        def update(self, id):
-            # this does some logic
+    @method("get")
+    @method("post")
+    def update(self, id):
+        ...
 
 Hope you are happy.
 
@@ -682,7 +683,7 @@ Just a bit of warning. Be careful when you decide to combine these two ways. Wha
     @method("post")
     @route("update/<int:id>")
     def update(self, id):
-        # this does some logic
+        ...
 
 Well, ``@method("post")`` is ignored, and you only get ``update`` with method ``GET``. So be careful.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -635,6 +635,57 @@ route:
 **method**    GET, POST
 ============ ================================
 
+"But I don't want all endpointes use same method!" I hear you cry. Worry not!
+You have two options how to create endpoint with different methods.
+
+Let's see the first one: ::
+    from flask_classful import route
+
+    class MyResourceView(FlaskView):
+
+        def edit(self, id):
+            # this shows some template probably
+
+        @route("update/<id>", methods=["POST"])
+        def update(self, id):
+            # this does some logic
+
+``@route`` is an old friend of ours, but I didn't tell you earlier that it can also set methods, right? Well, now you know. As you can see, ``methods`` can accept multiple values, so you can set multiple methods for one endpoint (but again, but recommanded).
+
+But there's also a second way, that some might consider nicer: ::
+
+    from flask_classful import method
+
+    class MyResourceView(FlaskView):
+
+        def edit(self, id):
+            # this shows some template probably
+
+        @method("post")
+        def update(self, id):
+            # this does some logic
+
+``@method`` is a new decorator (since v0.16), that can be used to set method for one endpoint. So, if you only want to set method, and not custom route, this is the way to go.
+By the way, you can write either ``post`` or ``POST``, that's up to your preference.
+
+What? You ask if you can have multiple methods for same endpoint with this decorator? Didn't you hear about why it's not that great? Ugh, ok, here you are: ::
+
+        @method("get")
+        @method("post")
+        def update(self, id):
+            # this does some logic
+
+Hope you are happy.
+
+Just a bit of warning. Be careful when you decide to combine these two ways. What would you guess happens when you do this? ::
+
+    @method("post")
+    @route("update/<int:id>")
+    def update(self, id):
+        # this does some logic
+
+Well, ``@method("post")`` is ignored, and you only get ``update`` with method ``GET``. So be careful.
+
 Hiding your own methods (they're not *all* special!)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
To my knowledge, documentation on setting custom method for endpoints is incomplete.

For a long time, way to go was `@route("something", methods=["POST"]`.  
Now we have `@method` decorator to make things easier.

It seems good to have these in docs.

Will be thankful for proofreading, change suggestions and any feedback in general.

closes #163