### PR TITLE
Fix failing lock flow due to longer `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -19,7 +19,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           issue-inactive-days: 14
           pr-inactive-days: 14


### PR DESCRIPTION
Fix the "github-token length must be less than or equal to 100 characters" failure caused by `GITHUB_TOKEN` exceeding the validator's upper bound (dessant/lock-threads#55).